### PR TITLE
run tools with yaml config

### DIFF
--- a/cmd/spycat/main.go
+++ b/cmd/spycat/main.go
@@ -37,7 +37,7 @@ func main() {
 		fmt.Printf("%v", err)
 	}
 	// init log
-	log.LogInit()
+	log.LogInit(config.YamlConfigGlobal.Log.Path, log.LevelTransform(config.YamlConfigGlobal.Log.Level))
 
 	sigCh := make(chan os.Signal, 1)
 	if os.Getenv("ENABLE_SPYCAT_PPROF") == "true" {
@@ -50,11 +50,20 @@ func main() {
 	}
 
 	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
-	cmd := app.NewCmd()
-	app.SubCmdInit(cmd)
-	// app.Start()
-	// go uprobe.NewBpfSession("uprobe", &core.SessionConfig{}).Start()
-	cmd.RootCmd.Execute()
+	// run with yaml
+	if config.ConfigWithYaml() {
+		err := config.RunWithYaml()
+		if err != nil {
+			log.Loger.Error("run with yaml failed:%v\n", err)
+		}
+	} else {
+		// run with cmd
+		cmd := app.NewCmd()
+		app.SubCmdInit(cmd)
+		// app.Start()
+		// go uprobe.NewBpfSession("uprobe", &core.SessionConfig{}).Start()
+		cmd.RootCmd.Execute()
+	}
 	// waitSignal(sigCh)
 }
 

--- a/pkg/app/cmd.go
+++ b/pkg/app/cmd.go
@@ -199,7 +199,7 @@ func newOffCpuSpyCmd(cfg *config.OFFCPU) *cobra.Command {
 			return RunSpy(cfg, conf, func(cfg interface{}, buf chan *model.SpyEvent) core.BpfSpyer {
 				config, ok := cfg.(*config.OFFCPU)
 				if ok {
-					return cpu.NewOffCpuBpfSession(model.OnCpu, config, buf)
+					return cpu.NewOffCpuBpfSession(model.OffCpu, config, buf)
 				}
 				return nil
 			})

--- a/pkg/component/detector/cpudetector/cpudetector.go
+++ b/pkg/component/detector/cpudetector/cpudetector.go
@@ -295,6 +295,10 @@ func (c *CpuDetector) formatFutexSnoopLabels(e *model.SpyEvent) (*model.Attribut
 			labels.AddStringValue(model.Stack, string(userAttributes.GetValue()))
 		}
 	}
+	labels.AddIntValue(model.Pid, int64(e.Task.Pid))
+	labels.AddIntValue(model.Tid, int64(e.Task.Tid))
+	labels.AddStringValue(model.Comm, strings.Replace(string(e.Task.Comm), "\u0000", "", -1))
+
 	return labels, nil
 }
 
@@ -356,8 +360,8 @@ func (c *CpuDetector) futexsnoopHandler(e *model.SpyEvent) (*model.DataBlock, er
 
 func (c *CpuDetector) syscallHandler(e *model.SpyEvent) (*model.DataBlock, error) {
 	labels, _ := c.formatSyscallLabels(e)
-	val := e.GetUintUserAttribute("dur_ms")
-	metric := model.NewIntMetric(model.Syscall, int64(val))
+	val := e.GetUintUserAttribute("dur_us")
+	metric := model.NewIntMetric(model.SyscallMetricName, int64(val))
 	return model.NewDataBlock(model.Syscall, labels, e.TimeStamp, metric), nil
 }
 

--- a/pkg/component/exporter/sqlite/sqlite_test.go
+++ b/pkg/component/exporter/sqlite/sqlite_test.go
@@ -58,9 +58,63 @@ func TestSqlite(t *testing.T) {
 		labels.AddIntValue(model.Pid, 111)
 		labels.AddIntValue(model.Tid, 112)
 		labels.AddStringValue(model.Comm, "target")
+		labels.AddStringValue(model.Stack, "a;b;c")
 		metric := model.NewIntMetric(model.OnCpuMetricName, 111)
 		dataBlock := model.NewDataBlock(model.OnCpu, labels, 2312341234, metric)
 		sqlite.Consume(dataBlock)
 	}
+
+	// test for futexsnoop
+	for i := 0; i < 1002; i++ {
+		labels := model.NewAttributeMap()
+		labels.AddIntValue(model.UserCnt, 20)
+		labels.AddIntValue(model.MaxUserCnt, 100)
+		labels.AddIntValue(model.LockAddr, 12312313)
+		labels.AddIntValue(model.MinDur, 50)
+		labels.AddIntValue(model.MaxDur, 200)
+		labels.AddIntValue(model.DeltaDur, 120)
+		labels.AddIntValue(model.AvgDur, 120)
+		labels.AddIntValue(model.LockCnt, 10)
+		labels.AddStringValue(model.Stack, "a;b;c")
+		labels.AddStringValue(model.Comm, "comm")
+		labels.AddIntValue(model.Pid, 111)
+		labels.AddIntValue(model.Tid, 112)
+
+		metric := model.NewIntMetric(model.FutexMaxUerCountName, 22)
+		dataBlock := model.NewDataBlock(model.FutexSnoop, labels, 1231231223, metric)
+		sqlite.Consume(dataBlock)
+	}
+
+	// test for syscall
+	for i := 0; i < 1002; i++ {
+		labels := model.NewAttributeMap()
+		labels.AddIntValue(model.DurUs, 1000)
+		labels.AddStringValue(model.Syscall, "write")
+		labels.AddStringValue(model.Stack, "a;b;c")
+		labels.AddIntValue(model.Pid, 111)
+		labels.AddIntValue(model.Tid, 112)
+		labels.AddStringValue(model.Comm, "comm")
+
+		metric := model.NewIntMetric(model.SyscallMetricName, 1212)
+		dataBlock := model.NewDataBlock(model.Syscall, labels, 12313123412, metric)
+		sqlite.Consume(dataBlock)
+	}
+
+	// test for cachestat
+	for i := 0; i < 1002; i++ {
+		labels := model.NewAttributeMap()
+		labels.AddIntValue(model.Pid, 1234)
+		labels.AddIntValue(model.Cpu, 0)
+		labels.AddIntValue(model.Count, 100000)
+		labels.AddIntValue(model.ReadSizeM, 1000)
+		labels.AddIntValue(model.WriteSizeM, 2000)
+		labels.AddStringValue(model.Comm, "cachestat")
+		labels.AddStringValue(model.File, "cache.log")
+
+		metric := model.NewIntMetric(model.CacheStatMetricName, 10000)
+		dataBlock := model.NewDataBlock(model.CacheStat, labels, 1232141234, metric)
+		sqlite.Consume(dataBlock)
+	}
+
 	time.Sleep(time.Second * 2)
 }

--- a/pkg/component/exporter/sqlite/table.go
+++ b/pkg/component/exporter/sqlite/table.go
@@ -51,3 +51,55 @@ type ONCPU struct {
 func (o *ONCPU) TableName() string {
 	return "ONCPU"
 }
+
+type SYSCALL struct {
+	ID       uint64    `gorm:"primaryKey"`
+	CreateAt time.Time `gorm:"autoCreateTime"`
+	Comm     string    `gorm:"size:16"`
+	Pid      uint32
+	Tid      uint32
+	Stack    string `gorm:"size:100"`
+	DurUs    uint32
+	Syscall  string
+}
+
+func (s *SYSCALL) TableName() string {
+	return "SYSCALL"
+}
+
+type FUTEXSNOOP struct {
+	ID         uint64    `gorm:"primaryKey"`
+	CreateAt   time.Time `gorm:"autoCreateTime"`
+	Comm       string    `gorm:"size:16"`
+	Pid        uint32
+	Tid        uint32
+	Stack      string `gorm:"size:100"`
+	UserCnt    uint32
+	MaxUserCnt uint32
+	LockAddr   int64
+	MinDurUS   uint32
+	MaxDurUs   uint32
+	AvgDurUs   uint32
+	DeltaDurUs uint32
+	LockCnt    uint32
+}
+
+func (f *FUTEXSNOOP) TableName() string {
+	return "FUTEXSNOOP"
+}
+
+type CACHESTAT struct {
+	ID         uint64    `gorm:"primaryKey"`
+	CreateAt   time.Time `gorm:"autoCreateTime"`
+	Comm       string    `gorm:"size:16"`
+	Pid        uint32
+	Cpu        uint32
+	ReadSizeM  uint32
+	WriteSizeM uint32
+	Cnt        uint32
+	File       string
+}
+
+func (c *CACHESTAT) TableName() string {
+	return "CACHESTAT"
+}

--- a/pkg/component/processor/processor.go
+++ b/pkg/component/processor/processor.go
@@ -158,13 +158,13 @@ func (d *DefaultProcessor) Consume(data *model.DataBlock) error {
 		fallthrough
 	case model.FutexSnoop:
 		fallthrough
+	case model.OnCpu:
+		fallthrough
 	case model.CacheStat:
 		err := d.consumer.Consume(data)
 		if err != nil {
 			log.Loger.Error("exporter consume data failed:%v", err)
 		}
-	// oncpu直接upstream
-	case model.OnCpu:
 	}
 	return nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,73 +3,253 @@ package config
 import (
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
-	"gopkg.in/yaml.v2"
+	appspy "github.com/chentao-kernel/spycat/internal/app"
+	"github.com/chentao-kernel/spycat/pkg/app/config"
+	"github.com/chentao-kernel/spycat/pkg/core"
+	"github.com/chentao-kernel/spycat/pkg/core/model"
+	"github.com/chentao-kernel/spycat/pkg/ebpf/cpu"
+	"github.com/chentao-kernel/spycat/pkg/ebpf/mem"
+	"github.com/chentao-kernel/spycat/pkg/util"
+	"gopkg.in/yaml.v3"
 )
 
 var (
-	configPath   = "spycat.yaml"
-	ConfigGlobal *Config
+	configPath       = "spycat.yaml"
+	YamlConfigGlobal *Config
+	ENABLE           = "enable"
+	DISENABLE        = "disable"
 )
 
+type ToolsConfig struct {
+	Tools      []string // enable tools list
+	Futexsnoop config.FUTEXSNOOP_YAML
+	Offcpu     config.OFFCPU_YAML
+	Syscall    config.SYSCALL_YAML
+	Oncpu      config.ONCPU_YAML
+	Cachestat  config.CACHESTAT_YAML
+}
+
+var ToolsConfigGlobal = ToolsConfig{}
+
+func initToolsConfig(toolsConfig *ToolsConfig, cfg *Config) {
+	for _, cf := range cfg.Inputs {
+		switch cf.Type {
+		case model.OffCpu:
+			val, ok := cf.Config.(*config.OFFCPU_YAML)
+			if ok {
+				toolsConfig.Offcpu = *val
+				if val.Status == ENABLE {
+					toolsConfig.Tools = append(toolsConfig.Tools, model.OffCpu)
+				}
+			}
+		case model.OnCpu:
+			val, ok := cf.Config.(*config.ONCPU_YAML)
+			if ok {
+				toolsConfig.Oncpu = *val
+				if val.Status == ENABLE {
+					toolsConfig.Tools = append(toolsConfig.Tools, model.OnCpu)
+				}
+			}
+		case model.CacheStat:
+			val, ok := cf.Config.(*config.CACHESTAT_YAML)
+			if ok {
+				toolsConfig.Cachestat = *val
+				if val.Status == ENABLE {
+					toolsConfig.Tools = append(toolsConfig.Tools, model.CacheStat)
+				}
+			}
+		case model.Syscall:
+			val, ok := cf.Config.(*config.SYSCALL_YAML)
+			if ok {
+				toolsConfig.Syscall = *val
+				if val.Status == ENABLE {
+					toolsConfig.Tools = append(toolsConfig.Tools, model.Syscall)
+				}
+			}
+		case model.FutexSnoop:
+			val, ok := cf.Config.(*config.FUTEXSNOOP_YAML)
+			if ok {
+				toolsConfig.Futexsnoop = *val
+				if val.Status == ENABLE {
+					toolsConfig.Tools = append(toolsConfig.Tools, model.FutexSnoop)
+				}
+			}
+		}
+	}
+}
+
+func (i *InputConfig) UnmarshalYAML(value *yaml.Node) error {
+	// the raw struct layout corresponds to InputConfig
+	var raw struct {
+		Type   string    `yaml:"type"`
+		Config yaml.Node `yaml:"config"`
+	}
+
+	if err := value.Decode(&raw); err != nil {
+		return err
+	}
+
+	i.Type = raw.Type
+	switch i.Type {
+	case "futexsnoop":
+		var cfg config.FUTEXSNOOP_YAML
+		if err := raw.Config.Decode(&cfg); err != nil {
+			return err
+		}
+		i.Config = &cfg
+	case "offcpu":
+		var cfg config.OFFCPU_YAML
+		if err := raw.Config.Decode(&cfg); err != nil {
+			return err
+		}
+
+		i.Config = &cfg
+	case "syscall":
+		var cfg config.SYSCALL_YAML
+		if err := raw.Config.Decode(&cfg); err != nil {
+			return err
+		}
+		i.Config = &cfg
+	case "oncpu":
+		var cfg config.ONCPU_YAML
+		if err := raw.Config.Decode(&cfg); err != nil {
+			return err
+		}
+		i.Config = &cfg
+	case "cachestat":
+		var cfg config.CACHESTAT_YAML
+		if err := raw.Config.Decode(&cfg); err != nil {
+			return err
+		}
+		i.Config = &cfg
+	default:
+		return fmt.Errorf("unknown input type: %s", i.Type)
+	}
+	return nil
+}
+
+type LogConfig struct {
+	Path  string `yaml:"path"`
+	Level string `yaml:"level" `
+}
+
+type InputType interface{}
+
+// TODO move status filed in xx_YAML struct to InputConfig
+type InputConfig struct {
+	Type   string    `yaml:"type"`
+	Config InputType `yaml:"config"`
+	// Syscall *conf.SYSCALL_YAML `yaml:"syscall"`
+	// FutexSnoop *conf.FUTEXSNOOP_YAML `yaml:"futexsnoop"`
+	// Offcpu *conf.OFFCPU_YAML `yaml:"offcpu"`
+	// Oncpu *conf.ONCPU_YAML `yaml:"oncpu"`
+	// CacheStat *conf.CACHESTAT_YAML `yaml:"cachestat"`
+}
+
+type ProcessorConfig struct {
+	Type string `yaml:"type"`
+}
+
+type ExporterConfig struct {
+	Type string `yaml:"type"`
+}
+
 type Config struct {
-	Log struct {
-		Path  string `yaml:"Path"`
-		Level string `yaml:"Level"`
-	} `yaml:"log"`
-	Inputs []struct {
-		Type   string   `yaml:"Type"`
-		Common struct{} `yaml:"Common,omitempty"`
-	} `yaml:"inputs"`
-	Processors []struct {
-		Type   string   `yaml:"Type"`
-		Common struct{} `yaml:"Common,omitempty"`
-	} `yaml:"processors"`
-	Exporters []struct {
-		Type   string   `yaml:"Type"`
-		Common struct{} `yaml:"Common,omitempty"`
-	} `yaml:"exporters"`
+	Log        LogConfig         `yaml:"log"`
+	Inputs     []InputConfig     `yaml:"inputs"`
+	Processors []ProcessorConfig `yaml:processors`
+	Exporters  []ExporterConfig  `yaml:exporters`
 }
 
 var defaultConfig = Config{
-	Log: struct {
-		Path  string `yaml:"Path"`
-		Level string `yaml:"Level"`
-	}{
+	Log: LogConfig{
 		Path:  "/tmp/spycat/",
 		Level: "INFO",
 	},
-	Inputs: []struct {
-		Type   string   `yaml:"Type"`
-		Common struct{} `yaml:"Common,omitempty"`
-	}{
-		{Type: "default"},
+	Inputs: []InputConfig{
+		{
+			Type: "futexsnoop",
+			Config: &config.FUTEXSNOOP_YAML{
+				LogLevel:        "INFO",
+				AppName:         "futexsnoop_app",
+				Pid:             0,
+				Tid:             0,
+				MaxDurMs:        1000000,
+				MinDurMs:        1000,
+				SymbolCacheSize: 256,
+				Exporter:        "sqlite",
+				Status:          "disable",
+			},
+		},
+		{
+			Type: "syscall",
+			Config: &config.SYSCALL_YAML{
+				LogLevel:        "INFO",
+				AppName:         "syscall_app",
+				Pid:             0,
+				Tid:             0,
+				MaxDurMs:        10000,
+				MinDurMs:        1,
+				SymbolCacheSize: 256,
+				Stack:           false,
+				Exporter:        "sqlite",
+				Status:          "disable",
+			},
+		},
+		{
+			Type: "offcpu",
+			Config: &config.OFFCPU_YAML{
+				LogLevel:        "INFO",
+				AppName:         "offcpu_app",
+				Pid:             -1,
+				MaxOffcpuMs:     1000000000,
+				MinOffcpuMs:     0,
+				SymbolCacheSize: 256,
+				Exporter:        "sqlite",
+				Status:          "disable",
+			},
+		},
+		{
+			Type: "oncpu",
+			Config: &config.ONCPU_YAML{
+				LogLevel:        "INFO",
+				AppName:         "oncpu_app",
+				Cpu:             "-1",
+				SymbolCacheSize: 256,
+				Exporter:        "sqlite",
+				Status:          "disable",
+			},
+		},
+		{
+			Type: "cachestat",
+			Config: &config.CACHESTAT_YAML{
+				LogLevel:  "INFO",
+				AppName:   "cachestat_app",
+				Pid:       -1,
+				CacheType: 0,
+				Cpu:       -1,
+				Exporter:  "sqlite",
+				Status:    "disable",
+			},
+		},
 	},
-	Processors: []struct {
-		Type   string   `yaml:"Type"`
-		Common struct{} `yaml:"Common,omitempty"`
-	}{
+	Processors: []ProcessorConfig{
 		{Type: "processor_default"},
 	},
-	Exporters: []struct {
-		Type   string   `yaml:"Type"`
-		Common struct{} `yaml:"Common,omitempty"`
-	}{
+	Exporters: []ExporterConfig{
 		{Type: "exporter_stdout"},
 	},
 }
 
 func NewConfig() *Config {
-	return &Config{
-		Log:        defaultConfig.Log,
-		Inputs:     defaultConfig.Inputs,
-		Processors: defaultConfig.Processors,
-		Exporters:  defaultConfig.Exporters,
-	}
+	return &defaultConfig
 }
 
 func ConfigInit() error {
-	ConfigGlobal = NewConfig()
+	YamlConfigGlobal = NewConfig()
 
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
 		data, err := yaml.Marshal(defaultConfig)
@@ -85,16 +265,129 @@ func ConfigInit() error {
 		if err != nil {
 			return fmt.Errorf("yaml read failed:%v", err)
 		}
-		err = yaml.Unmarshal(data, ConfigGlobal)
+		err = yaml.Unmarshal(data, YamlConfigGlobal)
 		if err != nil {
 			return fmt.Errorf("yaml unmarshal failed:%v", err)
 		}
+		initToolsConfig(&ToolsConfigGlobal, YamlConfigGlobal)
+	}
+	return nil
+}
+
+func ConfigWithYaml() bool {
+	return len(ToolsConfigGlobal.Tools) > 0
+}
+
+func initSpy() error {
+	return nil
+}
+
+func runSpy(spy *appspy.AppSpy, cfg interface{}, cf *appspy.Config, cb func(interface{}, chan *model.SpyEvent) core.BpfSpyer) error {
+	err := spy.Init(cf)
+	if err != nil {
+		return fmt.Errorf("spy init failed:%v", err)
+	}
+	err = spy.Start()
+	if err != nil {
+		spy.Stop()
+		return fmt.Errorf("spy start failed:%v", err)
+	}
+	receiver := spy.GetReceiver()
+	spyer := cb(cfg, receiver.RcvChan())
+
+	go func() {
+		err := spyer.Start()
+		if err != nil {
+			fmt.Printf("bpfspy:%s, start failed:%v\n", spyer.Name(), err)
+		}
+	}()
+
+	fmt.Printf("trace event:%s start\n", spyer.Name())
+	return nil
+}
+
+func RunWithYaml() error {
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
+
+	cf := &appspy.Config{
+		Exporter: "sqlite",
+		Server:   "http://localhost:4040",
+	}
+	spy, err := appspy.NewAppSpy(cf)
+	if err != nil {
+		return err
+	}
+
+	for _, tool := range ToolsConfigGlobal.Tools {
+		var err error
+		switch tool {
+		case model.OffCpu:
+			var offcpu config.OFFCPU
+			util.CopyStruct(&ToolsConfigGlobal.Offcpu, &offcpu)
+			err = runSpy(spy, &offcpu, cf, func(cfg interface{}, buf chan *model.SpyEvent) core.BpfSpyer {
+				cf, ok := cfg.(*config.OFFCPU)
+				if ok {
+					return cpu.NewOffCpuBpfSession(model.OffCpu, cf, buf)
+				}
+				return nil
+			})
+		case model.OnCpu:
+			var oncpu config.ONCPU
+			util.CopyStruct(&ToolsConfigGlobal.Oncpu, &oncpu)
+			err = runSpy(spy, &oncpu, cf, func(cfg interface{}, buf chan *model.SpyEvent) core.BpfSpyer {
+				cf, ok := cfg.(*config.ONCPU)
+				if ok {
+					return cpu.NewOnCpuBpfSession(model.OnCpu, cf, buf)
+				}
+				return nil
+			})
+		case model.CacheStat:
+			var cachestat config.CACHESTAT
+			util.CopyStruct(&ToolsConfigGlobal.Cachestat, &cachestat)
+			err = runSpy(spy, &cachestat, cf, func(cfg interface{}, buf chan *model.SpyEvent) core.BpfSpyer {
+				cf, ok := cfg.(*config.CACHESTAT)
+				if ok {
+					return mem.NewCacheStatBpfSession(model.CacheStat, cf, buf)
+				}
+				return nil
+			})
+		case model.Syscall:
+			var syscal config.SYSCALL
+			util.CopyStruct(&ToolsConfigGlobal.Syscall, &syscal)
+			err = runSpy(spy, &syscal, cf, func(cfg interface{}, buf chan *model.SpyEvent) core.BpfSpyer {
+				cf, ok := cfg.(*config.SYSCALL)
+				if ok {
+					return cpu.NewSyscallSession(model.Syscall, cf, buf)
+				}
+				return nil
+			})
+		case model.FutexSnoop:
+			var futexsnoop config.FUTEXSNOOP
+			util.CopyStruct(&ToolsConfigGlobal.Futexsnoop, &futexsnoop)
+			err = runSpy(spy, &futexsnoop, cf, func(cfg interface{}, buf chan *model.SpyEvent) core.BpfSpyer {
+				cf, ok := cfg.(*config.FUTEXSNOOP)
+				if ok {
+					return cpu.NewFutexSnoopSession(model.FutexSnoop, cf, buf)
+				}
+				return nil
+			})
+		}
+
+		if err != nil {
+			return err
+		}
+	}
+	select {
+	case s := <-sig:
+		fmt.Printf("Received signal and exit:%d", s)
+		os.Exit(0)
 	}
 	return nil
 }
 
 func GetConfig() *Config {
-	return ConfigGlobal
+	return YamlConfigGlobal
 }
 
 func (c *Config) ConfigLog() {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,25 @@
+package config
+
+import (
+	conf "github.com/chentao-kernel/spycat/pkg/app/config"
+	"testing"
+)
+
+func TestConfigInit(t *testing.T) {
+	// init first for generate spycat.yaml
+	err := ConfigInit()
+	if err != nil {
+		t.Errorf("test config init failed")
+	}
+	// init again for read spycat.yaml
+	err = ConfigInit()
+	if err != nil {
+		t.Errorf("test config init failed")
+	}
+	syscall, ok := defaultConfig.Inputs[1].Config.(*conf.SYSCALL_YAML)
+	if ok {
+		if syscall.AppName != ToolsConfigGlobal.Syscall.AppName {
+			t.Errorf("get yaml config failed,%s,%s", syscall.AppName, ToolsConfigGlobal.Syscall.AppName)
+		}
+	}
+}

--- a/pkg/core/model/const.go
+++ b/pkg/core/model/const.go
@@ -26,6 +26,7 @@ const (
 	FutexMaxUerCountName = "max_futex_user_cnt"
 	CacheStatMetricName  = "cachestat_read_size"
 	OnCpuMetricName      = "oncpu_hit_count"
+	SyscallMetricName    = "syscall_dur_us"
 )
 
 // for labels

--- a/pkg/ebpf/cpu/futexsnoop/futexsnoop.bpf.c
+++ b/pkg/ebpf/cpu/futexsnoop/futexsnoop.bpf.c
@@ -186,8 +186,8 @@ int futex_exit(struct syscall_trace_exit *ctx)
 	histp = bpf_map_lookup_or_try_init(&hists_map, &hkey, &initial_hist);
 	if (!histp)
 		goto cleanup;
-
-	delta /= 1000000U;
+	/* use us unit */
+	delta /= 1000U;
 
 	slot = log2l(delta);
 	if (slot >= MAX_SLOTS)

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	iner "github.com/chentao-kernel/spycat/internal"
-	"github.com/chentao-kernel/spycat/pkg/config"
 	"github.com/sirupsen/logrus"
 )
 
@@ -31,7 +30,7 @@ func (l *Logger) SetLevel(level logrus.Level) {
 	Loger.logger.SetLevel(Loger.level)
 }
 
-func levelTransform(level string) logrus.Level {
+func LevelTransform(level string) logrus.Level {
 	switch level {
 	case "PANIC":
 		return logrus.InfoLevel
@@ -51,26 +50,16 @@ func levelTransform(level string) logrus.Level {
 	return logrus.InfoLevel
 }
 
-func NewLogger() *Logger {
-	var configPath string
-	var level logrus.Level
-
-	if config.ConfigGlobal != nil {
-		configPath = config.ConfigGlobal.Log.Path
-		level = levelTransform(config.ConfigGlobal.Log.Level)
-	} else {
-		configPath = PATH
-		level = logrus.InfoLevel
-	}
-	if !iner.Exists(configPath) {
-		err := os.MkdirAll(configPath, 0755)
+func NewLogger(filePath string, level logrus.Level) *Logger {
+	if !iner.Exists(filePath) {
+		err := os.MkdirAll(filePath, 0755)
 		if err != nil {
-			log.Fatalf("mkdir %s failed.", configPath)
+			log.Fatalf("mkdir %s failed.", filePath)
 		}
 	}
 
 	fileName := time.Now().Format("20060102_15:04:05") + ".log"
-	file, err := os.OpenFile(configPath+"/"+fileName, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+	file, err := os.OpenFile(filePath+"/"+fileName, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 	if err != nil {
 		panic(fmt.Sprintf("New logger failed:%v", err))
 	}
@@ -84,8 +73,8 @@ func NewLogger() *Logger {
 	}
 }
 
-func LogInit() {
-	Loger = NewLogger()
+func LogInit(filePath string, level logrus.Level) {
+	Loger = NewLogger(filePath, level)
 	Loger.logger.SetOutput(Loger.file)
 	Loger.logger.SetLevel(Loger.level)
 	// output file name and function name

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"math"
 	"net"
@@ -303,4 +304,36 @@ func HostIp() (string, error) {
 		}
 	}
 	return "", fmt.Errorf("eth0 addr not found")
+}
+
+func CopyStruct(src interface{}, dest interface{}) error {
+	srcVal := reflect.ValueOf(src)
+	destVal := reflect.ValueOf(dest)
+
+	if srcVal.Kind() == reflect.Ptr {
+		if srcVal.IsNil() {
+			return errors.New("src pointer is nil")
+		}
+		srcVal = srcVal.Elem()
+	}
+
+	if destVal.Kind() == reflect.Ptr {
+		if destVal.IsNil() {
+			return errors.New("dest pointer is nil")
+		}
+		destVal = destVal.Elem()
+	}
+
+	if srcVal.Kind() != reflect.Struct {
+		return errors.New("src must be a struct")
+	}
+	if destVal.Kind() != reflect.Struct {
+		return errors.New("dest must be a struct")
+	}
+
+	for i := 0; i < srcVal.NumField(); i++ {
+		destVal.Field(i).Set(srcVal.Field(i))
+	}
+
+	return nil
 }


### PR DESCRIPTION
Now, tools can run with yaml config, and we can run offcpu and oncpu both.
log:
    path: /tmp/spycat/
    level: INFO
inputs:
    - type: futexsnoop
      config:
        log_level: INFO
        app_name: futexsnoop_app
        server: ""
        pid: 0
        tid: 0
        max_dur_ms: 1000000
        min_dur_ms: 1000
        symbol_cache_size: 256
        max_lock_hold_users: 0
        target_lock: false
        btf_path: ""
        exporter: sqlite
        status: disable
    - type: syscall
      config:
        log_level: INFO
        app_name: syscall_app
        server: ""
        pid: 0
        tid: 0
        max_dur_ms: 10000
        min_dur_ms: 1
        syscall: ""
        symbol_cache_size: 256
        stack: false
        btf_path: ""
        exporter: sqlite
        status: disable
    - type: offcpu
      config:
        log_level: INFO
        app_name: offcpu_app
        server: ""
        pid: -1
        max_offcpu_ms: 1000000000
        min_offcpu_ms: 0
        symbol_cache_size: 256
        rq_dur_ms: 0
        btf_path: ""
        exporter: sqlite
        status: disable
    - type: oncpu
      config:
        log_level: INFO
        app_name: oncpu_app
        sample_rate: 0
        server: ""
        upload_threads: 2
        upload_timeout: 100s
        upload_rate: 10s
        cpu: "-1"
        symbol_cache_size: 256
        btf_path: ""
        exporter: sqlite
        status: enable
    - type: cachestat
      config:
        log_level: INFO
        app_name: cachestat_app
        server: ""
        upload_rate: 0s
        pid: -1
        cache_type: 0
        cpu: -1
        btf_path: ""
        exporter: sqlite
        status: disable
processors:
    - type: processor_default
exporters:
    - type: exporter_stdout